### PR TITLE
Flatpak

### DIFF
--- a/.github/workflows/build-aux.yml
+++ b/.github/workflows/build-aux.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: SnowflakePowered/librashader
-          ref: '029cd36cdf4963e8d9501d912689549254f50f0c'
+          ref: 'cbdbdafecdfd6113ef1cdc15e0a4140b46420f0b'
           fetch-depth: 0
           path: librashader
           

--- a/packaging/dev.ares.ares.metainfo.xml
+++ b/packaging/dev.ares.ares.metainfo.xml
@@ -5,9 +5,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>ISC</project_license>
   <name>ares</name>
-  <summary>multi-system console emulation suite</summary>
+  <summary>Multi-system console emulation suite</summary>
   <description>
-    <p>ares is a multi-system emulator with the following features:</p>
+    <p>ares is a cross-platform, open source, multi-system emulator, focusing on accuracy and preservation. ares includes the following features:</p>
     <ul>
       <li>Native multi-platform UI</li>
       <li>Adaptive sync</li>
@@ -141,7 +141,9 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://ares-emu.net</url>
-  <developer_name>ares team</developer_name>
+  <developer id="dev.ares">
+    <name>ares team</name>
+  </developer>
   <provides>
     <binary>ares</binary>
   </provides>

--- a/packaging/dev.ares.ares.yaml
+++ b/packaging/dev.ares.ares.yaml
@@ -3,12 +3,8 @@ runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.rust-stable:
-    version: '24.08'
-    remove-after-build: true
-  - org.freedesktop.Sdk.Extension.llvm19:
-    version: '24.08'
-    remove-after-build: true
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.llvm19
 command: ares
 rename-desktop-file: ares.desktop
 rename-icon: ares
@@ -27,7 +23,6 @@ modules:
       env:
         CARGO_HOME: /run/build/librashader/cargo
     build-commands:
-      - rustup --version
       - cargo run -p librashader-build-script -- --profile optimized --stable
       - mkdir ${FLATPAK_DEST}/lib && cp -r target/optimized/librashader.so ${FLATPAK_DEST}/lib/librashader.so
       - mkdir -p ${FLATPAK_DEST}/include/librashader/ && cp -r include/* ${FLATPAK_DEST}/include/librashader/      


### PR DESCRIPTION
* CI: Bump Librashader down to v0.5.1
* dev.ares.ares.metainfo.xml: Validated using appstreamcli
* dev.ares.ares.yaml: Removed extraneous sdk-extensions lines, removed rustup --version line